### PR TITLE
Styling updates

### DIFF
--- a/dockerfiles/grist/ressources/ANCT/custom.css
+++ b/dockerfiles/grist/ressources/ANCT/custom.css
@@ -4,3 +4,20 @@
   --grist-theme-logo-bg: #ffffff !important;
   --grist-theme-logo-size: 22px 22px !important;
 }
+
+/* START Form custom colors to have WCAG compliant combinations */
+/* make sure the green grist color is WCAG compliant + make sure input borders are WCAG compliant */
+:root[data-grist-form] {
+  /* apply the grist HighContrastLight theme green colors */
+  --grist-theme-primary: #0f7b51;
+  --grist-theme-primary-muted: #196C47;
+  --grist-theme-primary-dim: #196C47;
+  --grist-theme-secondary: #717178;
+}
+
+/* note: here, we target specific things, as the dark-grey variable is used for other
+things that inputs and we don't want to change it in that case (ie. sections) */
+:root[data-grist-form] :is(input, select, textarea, label, .test-form-search-select) {
+  --grist-color-dark-grey: #8F8F8F;
+}
+/* END Form custom colors */

--- a/dockerfiles/grist/ressources/DINUM/custom.css
+++ b/dockerfiles/grist/ressources/DINUM/custom.css
@@ -85,6 +85,18 @@
   /* END Custom tooltip colors */
   /* END light theme-specific overrides */
 
+  /* START Form custom colors to have WCAG compliant combinations */
+  /* Forms don't support themes. They are always loaded with GristLight theme,
+  but don't necessarily consume the same tokens as components in the app
+  and need some specific overrides. */
+
+  /* note: here, we target specific things, as the dark-grey variable is used for other
+  things that inputs and we don't want to change it in that case (ie. sections) */
+  :root[data-grist-form] :is(input, select, textarea, label, .test-form-search-select) {
+    --grist-color-dark-grey: #8F8F8F;
+  }
+  /* END Form custom colors */
+
   /* START dark theme-specific overrides */
   :root[data-grist-theme="GristDark"] {
     --grist-theme-body: #f6f6f6;

--- a/dockerfiles/grist/ressources/DINUM/custom.css
+++ b/dockerfiles/grist/ressources/DINUM/custom.css
@@ -51,6 +51,17 @@
     --grist-theme-decoration-tertiary: #d2d2d2;
     /* make switches use the same color as switches from the DSFR (instead of the lighter blue) */
     --grist-theme-switch-active-slider: var(--grist-theme-primary-dim);
+
+    /* make _some_ important borders more pronounced so that they are WCAG compliant by default
+    (no need to do that on the HighContrastLight theme, as they are already WCAG compliant) */
+    --custom-marked-borders: #8F8F8F;
+    --grist-theme-input-border: var(--custom-marked-borders);
+    --grist-theme-app-header-border: var(--custom-marked-borders);
+    --grist-theme-select-button-border: var(--custom-marked-borders);
+    --grist-theme-button-group-border: var(--custom-marked-borders);
+    --grist-theme-highlighted-code-border: var(--custom-marked-borders);
+    --grist-theme-checkbox-border: var(--custom-marked-borders);
+    --grist-theme-page-panels-border: #cfcfcf;
   }
 
   /* when in a table or card, the toggle switch has particular styling rules to handle potential user-selected color,

--- a/dockerfiles/grist/ressources/DINUM/custom.css
+++ b/dockerfiles/grist/ressources/DINUM/custom.css
@@ -49,6 +49,14 @@
     --grist-theme-decoration: #d2d2d2;
     --grist-theme-decoration-secondary: #e8e8e8;
     --grist-theme-decoration-tertiary: #d2d2d2;
+    /* make switches use the same color as switches from the DSFR (instead of the lighter blue) */
+    --grist-theme-switch-active-slider: var(--grist-theme-primary-dim);
+  }
+
+  /* when in a table or card, the toggle switch has particular styling rules to handle potential user-selected color,
+  making it a impossible to override only with a CSS variable, we must force a rule */
+  [data-grist-theme="GristLight"] .field_clip .test-toggle-switch {
+    --grist-theme-switch-active-slider: var(--grist-actual-cell-color, var(--grist-theme-primary-dim)) !important;
   }
 
   :root[data-grist-theme="HighContrastLight"] {


### PR DESCRIPTION
This applies some styling changes on both the DINUM and ANCT instances.

DINUM:

- fix the toggle switch color not matching the DSFR style (thanks @tayflo)
- make input borders more pronounced by default as it's the main issue with colors on the default light theme
- make public form input borders WCAG compliant, thanks to custom CSS being supported on those pages

ANCT :

- make public form colors WCAG compliant, thanks to custom CSS being supported on those pages