### PR TITLE
[depandabot]: Change update type to semver-minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types:
-          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
It seems that we only want minor updates, cause we want to stick to the major versions grist-core relies on.